### PR TITLE
[hotfix] オフラインのプレイヤーのチェストが開けれてしまった問題

### DIFF
--- a/src/main/java/life/grass/grasshousing/ChestLockManager.java
+++ b/src/main/java/life/grass/grasshousing/ChestLockManager.java
@@ -48,6 +48,7 @@ public class ChestLockManager {
         
         JsonObject json = new JsonObject();
         json.addProperty("ownerUUID", owner.getUniqueId().toString());
+        json.addProperty("ownerName", owner.getName());
         return new Gson().toJson(json);
         
     }

--- a/src/main/java/life/grass/grasshousing/event/ChestLockEvent.java
+++ b/src/main/java/life/grass/grasshousing/event/ChestLockEvent.java
@@ -40,7 +40,12 @@ public class ChestLockEvent implements Listener {
 
             } else {
 
-                if (chest.getCustomName().equals(ChestLockManager.chestLockJson(player))) {
+
+                Gson gson = new Gson();
+                HashMap<String, String> str = gson.fromJson(chest.getCustomName(), HashMap.class);
+                String playerUUID = str.get("ownerUUID");
+
+                if (playerUUID.equals(player.getUniqueId().toString())) {
 
                     if (materialInHand.equals(Material.WOOD_BUTTON)) {
 
@@ -51,12 +56,15 @@ public class ChestLockEvent implements Listener {
 
                 } else {
 
-                    Gson gson = new Gson();
-                    HashMap<String, String> str = gson.fromJson(chest.getCustomName(), HashMap.class);
 
-                    player.sendTitle("", "この泥棒!! これは" + Bukkit.getPlayer(UUID.fromString(str.get("ownerUUID"))).getName() + "のチェストだ!!", 10, 70, 20);
+                    if (!StringUtils.isEmpty(str.get("ownerName"))) {
+                        player.sendTitle("", "この泥棒!! これは" + str.get("ownerName") + "のチェストだ!!", 10, 70, 20);
+                    } else {
+                        // 不具合解消以前に設置されたチェストに関して、ownerNameが記録されていないものに関する例外処理
+                        player.sendTitle("", "この泥棒!! これは君のチェストじゃない!!", 10, 70, 20);
+
+                    }
                     event.setCancelled(true);
-
                 }
             }
         }


### PR DESCRIPTION
原因はBukkit.getPlayer(UUID uuid)を用いて他人のチェストを開けた際のメッセージを表示していたために、オフラインのプレイヤーのチェストを開ける際にエラーが生じsetCancelled(true)が動作していなかったためであった。

従って、チェストのcustomNameにJsonを格納する際に持ち主の名前を入れ、それを表示することでこの問題に対処した。

また、すでにできてしまっている持ち主の名前のないチェストに関しての姑息的な対処も行った。